### PR TITLE
fix: omit undefined event metadata

### DIFF
--- a/server/__tests__/events.api.test.ts
+++ b/server/__tests__/events.api.test.ts
@@ -14,6 +14,15 @@ jest.mock('../utils/scrape', () => {
       deadline: false,
       tags: [],
     },
+    {
+      id: '2',
+      title: 'Missing Fields Event',
+      // intentionally omit source and category to test metadata filtering
+      organizer: 'test',
+      priority: 1,
+      deadline: false,
+      tags: [],
+    } as any,
   ];
   return {
     cache: {
@@ -34,5 +43,12 @@ describe('GET /api/events', () => {
     expect(res.status).toBe(200);
     expect(res.body.events.length).toBeGreaterThan(0);
     expect(res.body.metadata).toBeDefined();
+  });
+
+  it('omits undefined categories and sources from metadata', async () => {
+    const res = await request(app).get('/api/events');
+    expect(res.status).toBe(200);
+    expect(res.body.metadata.categories).toEqual(['general']);
+    expect(res.body.metadata.sources).toEqual(['https://example.org']);
   });
 });

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -10,19 +10,33 @@ router.get('/', async (_req, res) => {
   if (!events || ttl <= 0) {
     events = await scrapeAndCache();
   }
-  const meta = (await cache.get<{ lastUpdated: string }>('events:lastUpdated')) || {
-    lastUpdated: new Date().toISOString()
+  const meta = (await cache.get<{ lastUpdated: string }>(
+    'events:lastUpdated'
+  )) || {
+    lastUpdated: new Date().toISOString(),
   };
-  const categories = Array.from(new Set((events || []).map(e => e.category)));
-  const sources = Array.from(new Set((events || []).map(e => e.source)));
+  const categories = Array.from(
+    new Set(
+      (events || [])
+        .map((e) => e.category)
+        .filter((category): category is string => Boolean(category))
+    )
+  );
+  const sources = Array.from(
+    new Set(
+      (events || [])
+        .map((e) => e.source)
+        .filter((source): source is string => Boolean(source))
+    )
+  );
   res.json({
     events: events || [],
     metadata: {
       totalEvents: (events || []).length,
       lastUpdated: meta.lastUpdated,
       categories,
-      sources
-    }
+      sources,
+    },
   });
 });
 
@@ -34,7 +48,9 @@ router.post('/', async (req, res) => {
   const events = (await cache.get('events')) || [];
   events.push(event);
   await cache.set('events', events);
-  await cache.set('events:lastUpdated', { lastUpdated: new Date().toISOString() });
+  await cache.set('events:lastUpdated', {
+    lastUpdated: new Date().toISOString(),
+  });
   res.status(201).json(event);
 });
 


### PR DESCRIPTION
## Summary
- ensure `events` API does not include undefined categories or sources
- test that metadata categories and sources exclude undefined values

## Testing
- `npm test`
- `npm run lint:server`


------
https://chatgpt.com/codex/tasks/task_b_689fdd9753f48330b3f02992e25524c2